### PR TITLE
Fix imports for load_from_file, PageRenderer, RenderHint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 *.snm
 *.tex
 *.toc
+__pycache__
+.venv

--- a/Krisenter/Krisenter.py
+++ b/Krisenter/Krisenter.py
@@ -5,7 +5,8 @@
 
 import krita
 from PIL import Image
-from poppler import load_from_file, PageRenderer, RenderHint
+from poppler.document import load_from_file
+from poppler.pagerenderer import PageRenderer, RenderHint
 import tempfile,os
 import pikepdf
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,17 @@ Krisenter is licensed under the same license as krita, GPL v3.
 The installation has currently only been tested on a Linux box. I'll be happy to receive contributions for other platforms.
 
 1. Install the dependent python packages, e.g. with pip.
-  * pikeqdf
-  * poppler
+  * python-poppler
+  * sip 
+  * pikepdf 
+  * image 
+  * poppler-utils
+
 2. Run the script `install.sh` to install in the users home directory.
 3. Run Krita
 4. Choose Menu Item Settings→Configure Krita→Python Plugin Manager
 5. Activate:
   * Krisenter
-  * Next Slide
-  * Previous slide
 6. Restart Krita
 
 # Running

--- a/poppler_navigator.py
+++ b/poppler_navigator.py
@@ -8,7 +8,8 @@ Dov Grobgeld <dov.grobgeld@gmail.com>
 import os
 import tempfile
 from PIL import Image
-from poppler import load_from_file, PageRenderer, RenderHint
+from poppler.document import load_from_file
+from poppler.pagerenderer import PageRenderer, RenderHint
 from krita import *
 
 class PopplerNavigor:


### PR DESCRIPTION
I don't know if it is related to python version, I had to change here for Python 3.8.10 